### PR TITLE
feat: add man page generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,15 +60,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -76,11 +76,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "clap_mangen"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105180c05a72388d5f5e4e4f6c79eecb92497bda749fa8f963a16647c5d5377f"
+dependencies = [
+ "clap",
+ "roff",
 ]
 
 [[package]]
@@ -146,6 +156,7 @@ name = "git-view"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_mangen",
  "mockall",
  "test-case",
  "url",
@@ -319,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ exclude = [".github/**"]
 
 [[bin]]
 name = "git-view"
-path = "src/bin/git-view.rs"
 
 [lib]
 name = "git_view"
@@ -21,6 +20,10 @@ path = "src/lib.rs"
 clap = { version = '3.1.18', features = ["cargo"] }
 url = { version = '2.3.1' }
 webbrowser = { version = '0.8.2' }
+
+[build-dependencies]
+clap = { version = '3.1.18', features = ["cargo"] }
+clap_mangen = "0.1"
 
 [dev-dependencies]
 test-case = { version = '2.2.2' }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::{
+    env, fs,
+    io::{self, Write},
+    path::PathBuf,
+};
+
+#[path = "src/bin/git-view/cmd.rs"]
+mod cmd;
+
+fn main() -> io::Result<()> {
+    let out_dir: PathBuf = env::var_os("OUT_DIR")
+        .ok_or(io::ErrorKind::NotFound)?
+        .into();
+    fs::create_dir_all(&out_dir)?;
+    let mut manpage = fs::File::create(out_dir.join("git-view.1"))?;
+
+    let man = clap_mangen::Man::new(cmd::cmd());
+    man.render(&mut manpage)?;
+
+    Ok(())
+}

--- a/src/bin/git-view/cmd.rs
+++ b/src/bin/git-view/cmd.rs
@@ -1,19 +1,7 @@
-use std::panic::set_hook;
+use clap::{crate_authors, crate_version, Arg, Command};
 
-use clap::{command, crate_authors, crate_version, Arg, Command, ErrorKind};
-use git_view::Git;
-use git_view::GitView;
-
-macro_rules! clap_panic {
-    ($e:expr) => {
-        command!().error(ErrorKind::DisplayHelp, $e).exit()
-    };
-}
-
-fn main() {
-    set_hook(Box::new(|info| clap_panic!(info)));
-
-    let matches = Command::new("git-view")
+pub fn cmd() -> clap::Command<'static> {
+    Command::new("git-view")
         .version(crate_version!())
         .author(crate_authors!())
         .about(
@@ -74,19 +62,5 @@ This currently supports the following URLs:
                 .short('p')
                 .long("print")
                 .display_order(6),
-        );
-
-    let matches = matches.get_matches();
-    let mut git_view = GitView::new(
-        matches.value_of("branch"),
-        matches.value_of("remote"),
-        matches.value_of("commit"),
-        matches.value_of("suffix"),
-        matches.is_present("issue"),
-        matches.is_present("print"),
-    );
-
-    if let Err(app_error) = git_view.view_repository(Git) {
-        clap_panic!(app_error.error_str);
-    }
+        )
 }

--- a/src/bin/git-view/main.rs
+++ b/src/bin/git-view/main.rs
@@ -1,0 +1,31 @@
+use std::panic::set_hook;
+
+use clap::{command, ErrorKind};
+use git_view::Git;
+use git_view::GitView;
+
+mod cmd;
+
+macro_rules! clap_panic {
+    ($e:expr) => {
+        command!().error(ErrorKind::DisplayHelp, $e).exit()
+    };
+}
+
+fn main() {
+    set_hook(Box::new(|info| clap_panic!(info)));
+
+    let matches = cmd::cmd().get_matches();
+    let mut git_view = GitView::new(
+        matches.value_of("branch"),
+        matches.value_of("remote"),
+        matches.value_of("commit"),
+        matches.value_of("suffix"),
+        matches.is_present("issue"),
+        matches.is_present("print"),
+    );
+
+    if let Err(app_error) = git_view.view_repository(Git) {
+        clap_panic!(app_error.error_str);
+    }
+}


### PR DESCRIPTION
You can view the man page after running `cargo build` with

```sh
man -l $(find -name git-view.1)
```